### PR TITLE
Fix Exception that will occur later in course.

### DIFF
--- a/app/ch05_jinja_templates/final/pypi_org/infrastructure/view_modifiers.py
+++ b/app/ch05_jinja_templates/final/pypi_org/infrastructure/view_modifiers.py
@@ -10,6 +10,10 @@ def response(*, mimetype: str = None, template_file: str = None):
         @wraps(f)
         def view_method(*args, **kwargs):
             response_val = f(*args, **kwargs)
+
+            if isinstance(response_val, werkzeug.wrappers.response.Response):
+                return response_val
+            
             if isinstance(response_val, flask.Response):
                 return response_val
 


### PR DESCRIPTION
Exception will occur at time 4:15 in the video "User input and HTML forms: Getting the submitted values" of course "Building data-driven web apps with Flask and SQLAlchemy".

This exception happens because the flask.redirect() returns a werkzeug.wrappers.response.Response. The inserted condition will check for this response and return the redirect correctly. This fix likely needs to be added to other versions in the course files.

For more info, see email to Michael titled "please help: Exception in course 'building data-driven web apps...'" dated Sep 24, 2019, 1:48 PM.