### PR TITLE
Add client to import

### DIFF
--- a/app/ch14_testing/final/tests/package_tests.py
+++ b/app/ch14_testing/final/tests/package_tests.py
@@ -1,7 +1,7 @@
 import datetime
 import unittest.mock
 from flask import Response
-from tests.test_client import flask_app
+from tests.test_client import flask_app, client
 
 
 def test_package_details_success():


### PR DESCRIPTION
The following error appears without importing `client`:

```
E       fixture 'client' not found
>       available fixtures: cache, capfd, capfdbinary, caplog, capsys, capsysbinary, cov, doctest_namespace, monkeypatch, no_cover, pytestconfig, record_property, record_testsuite_property, record_xml_attribute, recwarn, tmp_path, tmp_path_factory, tmpdir, tmpdir_factory
>       use 'pytest --fixtures [testpath]' for help on them.
```

This is remedied by importing `client` as suggested.